### PR TITLE
ka-do移動機能を作成

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,7 +1,7 @@
 class CardsController < ApplicationController
   before_action :set_project
   before_action :set_column
-  before_action :set_card, only: %i[edit update destroy]
+  before_action :set_card, only: %i[edit update destroy previous next]
 
   def new
     @card = @column.cards.build
@@ -33,6 +33,16 @@ class CardsController < ApplicationController
   def destroy
     @card.destroy!
     redirect_to project_path(@project), notice: 'カードを削除しました'
+  end
+
+  def previous
+    @card.move_to_higher_column
+    redirect_to project_path(@project)
+  end
+
+  def next
+    @card.move_to_lower_column
+    redirect_to project_path(@project)
   end
 
   private

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -3,7 +3,19 @@ class Card < ApplicationRecord
   belongs_to :project
   belongs_to :column
 
+  acts_as_list scope: %i[project_id column_id]
+
   validates :name, presence: true,
                    uniqueness: { scope: :project },
                    length: { maximum: 40 }
+
+  def move_to_higher_column
+    self.column = column.higher_item
+    save
+  end
+
+  def move_to_lower_column
+    self.column = column.lower_item
+    save
+  end
 end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -10,11 +10,15 @@ class Card < ApplicationRecord
                    length: { maximum: 40 }
 
   def move_to_higher_column
+    return false if column.first?
+
     self.column = column.higher_item
     save
   end
 
   def move_to_lower_column
+    return false if column.last?
+
     self.column = column.lower_item
     save
   end

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -1,5 +1,5 @@
 class Column < ApplicationRecord
-  has_many :cards, dependent: :destroy
+  has_many :cards, -> { order(position: :desc) }, dependent: :destroy
   belongs_to :project
 
   acts_as_list scope: :project

--- a/app/views/projects/_card.html.slim
+++ b/app/views/projects/_card.html.slim
@@ -2,7 +2,7 @@
   .card-body.overflow-scroll.pt-3.pb-2
     .row
       .col-2.px-0.my-auto
-        = link_to '#', class: 'text-middle-purple hover-middle-purple' do
+        = link_to previous_project_column_card_path(project, column, card), class: column.arrow_link_class(:left) do
           i.far.fa-arrow-alt-circle-left.fa-lg
 
       .col.text-center.text-truncate.px-0
@@ -12,7 +12,7 @@
               .card-text.h6 = card.name
 
       .col-2.text-right.px-0.my-auto
-        = link_to '#', class: 'text-middle-purple hover-middle-purple' do
+        = link_to next_project_column_card_path(project, column, card), class: column.arrow_link_class(:right) do
           i.far.fa-arrow-alt-circle-right.fa-lg
 
     .row.mt-2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,10 @@ Rails.application.routes.draw do
     resources :columns, only: %i[new create edit update destroy] do
       get 'previous', on: :member
       get 'next', on: :member
-      resources :cards, only: %i[new create edit update destroy]
+      resources :cards, only: %i[new create edit update destroy] do
+        get 'previous', on: :member
+        get 'next', on: :member
+      end
     end
   end
 

--- a/db/migrate/20190614220936_add_position_to_card.rb
+++ b/db/migrate/20190614220936_add_position_to_card.rb
@@ -1,0 +1,5 @@
+class AddPositionToCard < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cards, :position, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_13_044843) do
+ActiveRecord::Schema.define(version: 2019_06_14_220936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2019_06_13_044843) do
     t.bigint "column_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position", null: false
     t.index ["assignee_id"], name: "index_cards_on_assignee_id"
     t.index ["column_id"], name: "index_cards_on_column_id"
     t.index ["project_id", "name"], name: "index_cards_on_project_id_and_name", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,9 @@
   )
 
   File.open("#{Rails.root}/public/avatar_sample.jpeg") do |file|
-    user.image.attach(file)
+    user.image.attach(io: file,
+                      filename: 'avatar_sample.jpeg',
+                      content_type: 'image/jpeg')
   end
 end
 
@@ -28,7 +30,7 @@ end
   Project.create!(
     name: "プロジェクト#{n + 1}",
     summary: "プロジェクト#{n + 1}の概要",
-    user_id: User.ids.sample
+    owner_id: User.ids.sample
   )
 end
 

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe Card, type: :model do
+  describe '#move_to_higher_column' do
+    let(:project) { create(:project) }
+
+    context '最後のカラムの中にあるカードの場合' do
+      let(:columns) { create_list(:column, 3, project: project) }
+      let(:card) { create(:card, project: project, column: columns.last) }
+
+      before do
+        create_list(:card, 3, project: project, column: columns.last.higher_item)
+      end
+
+      it '結果が正しいこと' do
+        expect(card.move_to_higher_column).to be_truthy
+      end
+
+      it '内容が正しいこと' do
+        card.move_to_higher_column
+        # カードはposition順に下から並ぶので、card.lastが一番上に表示される
+        expect(card.last?).to be_truthy
+        expect(card.column).to eq columns.last.higher_item
+      end
+    end
+
+    context '最初のカラムの中にあるカードの場合' do
+      let(:columns) { create_list(:column, 3, project: project) }
+      let(:card) { create(:card, project: project, column: columns.first) }
+
+      it '結果が正しいこと' do
+        expect(card.move_to_higher_column).to be_falsy
+      end
+    end
+
+    context '1つだけのカラムの中にあるカードの場合' do
+      let(:column) { create(:column, project: project) }
+      let(:card) { create(:card, project: project, column: column) }
+
+      it '結果が正しいこと' do
+        expect(card.move_to_higher_column).to be_falsy
+      end
+    end
+  end
+
+  describe '#move_to_lower_column' do
+    let(:project) { create(:project) }
+
+    context '最初のカラムの中にあるカードの場合' do
+      let(:columns) { create_list(:column, 3, project: project) }
+      let(:card) { create(:card, project: project, column: columns.first) }
+
+      before do
+        create_list(:card, 3, project: project, column: columns.first.lower_item)
+      end
+
+      it '結果が正しいこと' do
+        expect(card.move_to_lower_column).to be_truthy
+      end
+
+      it '内容が正しいこと' do
+        card.move_to_lower_column
+        # カードはposition順に下から並ぶので、card.lastが一番上に表示される
+        expect(card.last?).to be_truthy
+        expect(card.column).to eq columns.first.lower_item
+      end
+    end
+
+    context '最後のカラムの中にあるカードの場合' do
+      let(:columns) { create_list(:column, 3, project: project) }
+      let(:card) { create(:card, project: project, column: columns.last) }
+
+      it '結果が正しいこと' do
+        expect(card.move_to_lower_column).to be_falsy
+      end
+    end
+
+    context '1つだけのカラムの中にあるカードの場合' do
+      let(:column) { create(:column, project: project) }
+      let(:card) { create(:card, project: project, column: column) }
+
+      it '結果が正しいこと' do
+        expect(card.move_to_lower_column).to be_falsy
+      end
+    end
+  end
+end


### PR DESCRIPTION
ref #15 
カードの移動機能を作成しました。
- cardモデルにカード移動用のメソッド#move_to_higher_column、#move_to_lower_columnを作成
- CardsControllerにカード移動用のアクション#previous #nextを作成
カードの左右矢印押下でカードを左右のカラムに移動できるようにした。