### PR TITLE
参加機能を作成

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -5,7 +5,7 @@ class InvitationsController < ApplicationController
     @invitation_form = InvitationForm.new
   end
 
-  def index
+  def generate_invitaions
     @invitation_form = InvitationForm.new(invitation_params)
     @users = @invitation_form.search if @invitation_form.valid?
     render :invite

--- a/app/controllers/myprojects/projects_controller.rb
+++ b/app/controllers/myprojects/projects_controller.rb
@@ -2,7 +2,7 @@ class Myprojects::ProjectsController < ApplicationController
   before_action :set_project, only: %i[edit update destroy]
 
   def index
-    @projects = Project.for_myprojects_list(current_user, params[:page])
+    @projects = Project.for_accessible_list(current_user, params[:page])
     respond_to do |format|
       format.html
       format.js { render 'projects/index' }

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,0 +1,10 @@
+class ParticipationsController < ApplicationController
+  def create
+    project = current_user.invitation_projects.find(params[:project_id])
+    if current_user.participate_in(project)
+      redirect_to project_path(project), notice: 'プロジェクトに参加しました'
+    else
+      redirect_to project_path(project), alert: '処理に失敗しました'
+    end
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -8,4 +8,11 @@ class ProjectsController < ApplicationController
                       .includes(columns: :cards)
                       .find(params[:id])
   end
+
+  def info
+    @project = Project.accessible(current_user)
+                      .includes(:owner)
+                      .find(params[:project_id])
+    @members = @project.members.order(id: :asc)
+  end
 end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -8,6 +8,7 @@ class Card < ApplicationRecord
   validates :name, presence: true,
                    uniqueness: { scope: :project },
                    length: { maximum: 40 }
+  validate :verify_assignee
 
   def move_to_higher_column
     return false if column.first?
@@ -21,5 +22,14 @@ class Card < ApplicationRecord
 
     self.column = column.lower_item
     save
+  end
+
+  private
+
+  def verify_assignee
+    return if project.owner_id == assignee_id
+    return if project.members.exists?(assignee_id)
+
+    errors.add(:assignee, I18n.t('errors.messages.invalid'))
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -5,11 +5,5 @@ class Invitation < ApplicationRecord
   paginates_per 5
 
   validates :user, uniqueness: { scope: :project }
-  validate :verify_owner
-
-  private
-
-  def verify_owner
-    errors.add(:user, I18n.t('errors.messages.invalid')) if user.owner?(project)
-  end
+  validates :user, owner_rejection: true
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -6,4 +6,5 @@ class Invitation < ApplicationRecord
 
   validates :user, uniqueness: { scope: :project }
   validates :user, owner_rejection: true
+  validates :user, member_rejection: true
 end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,0 +1,13 @@
+class Participation < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+
+  validates :user, uniqueness: { scope: :project }
+  validate :verify_owner
+
+  private
+
+  def verify_owner
+    errors.add(:user, I18n.t('errors.messages.invalid')) if user.owner?(project)
+  end
+end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -3,11 +3,5 @@ class Participation < ApplicationRecord
   belongs_to :user
 
   validates :user, uniqueness: { scope: :project }
-  validate :verify_owner
-
-  private
-
-  def verify_owner
-    errors.add(:user, I18n.t('errors.messages.invalid')) if user.owner?(project)
-  end
+  validates :user, owner_rejection: true
 end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -4,4 +4,16 @@ class Participation < ApplicationRecord
 
   validates :user, uniqueness: { scope: :project }
   validates :user, owner_rejection: true
+
+  before_create :destroy_invitation!, if: :invited?
+
+  def invited?
+    user.invited?(project)
+  end
+
+  private
+
+  def destroy_invitation!
+    user.invitations.find_by!(project_id: project.id).destroy!
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -20,31 +20,39 @@ class Project < ApplicationRecord
     order(id: :desc).page(page).per(COUNT_PER_PAGE)
   end
 
-  scope :for_myprojects_list, ->(user, page) do
+  scope :for_accessible_list, ->(user, page) do
     if page
-      for_myprojects_second_page_or_later(user, page)
+      for_accessible_list_second_page_or_later(user, page)
     else
-      for_myprojects_first_page(user)
+      for_accessible_list_first_page(user)
     end
   end
 
-  scope :for_myprojects_first_page, ->(user) do
+  scope :for_accessible_list_first_page, ->(user) do
     count_for_first_page = COUNT_PER_PAGE - PADDING_COUNT
-    where(owner: user).order(id: :desc).page(nil).per(count_for_first_page)
+    accessible(user).order(id: :desc).page(nil).per(count_for_first_page)
   end
 
-  scope :for_myprojects_second_page_or_later, ->(user, page) do
+  scope :for_accessible_list_second_page_or_later, ->(user, page) do
     # もし1ページ目が指定されても値を返さないようにする
     # （kaminariのissueによると、1ページ目でpaddingマイナス値を使うと不具合がある）
     return [] if ['1', 1, nil].include?(page)
 
-    where(owner: user).order(id: :desc).page(page).per(COUNT_PER_PAGE)
-                      .padding(-PADDING_COUNT)
+    accessible(user).order(id: :desc).page(page).per(COUNT_PER_PAGE)
+                    .padding(-PADDING_COUNT)
   end
 
   scope :accessible, ->(user) do
-    # TODO: 招待機能を作成する際に、招待されたユーザもアクセス可能に設定すること
-    where(owner: user)
+    owned_by(user).or(participated_in_by(user)).distinct
+  end
+
+  scope :owned_by, ->(user) do
+    # .accessibleでorを使用できるようleft_joinsする
+    left_joins(:participations).where(owner_id: user.id)
+  end
+
+  scope :participated_in_by, ->(user) do
+    left_joins(:participations).where(participations: { user_id: user.id })
   end
 
   def accessible?(user)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,8 @@ class Project < ApplicationRecord
   has_many :cards, dependent: :destroy
   has_many :invitations, dependent: :destroy
   has_many :invited_users, through: :invitations, source: :user
+  has_many :participations, dependent: :destroy
+  has_many :members, through: :participations, source: :user
   belongs_to :owner, class_name: 'User', foreign_key: :owner_id
 
   # プロジェクト一覧で1ページに表示するプロジェクトの個数

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -62,4 +62,8 @@ class Project < ApplicationRecord
   def invite(user)
     invitations.build(user: user).save
   end
+
+  def accessible_users
+    [owner] + members
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,7 +2,7 @@ class Project < ApplicationRecord
   has_many :columns, -> { order(position: :asc) }, dependent: :destroy
   has_many :cards, dependent: :destroy
   has_many :invitations, dependent: :destroy
-  has_many :invited_users, through: :invitations, source: :user
+  has_many :invitees, through: :invitations, source: :user
   has_many :participations, dependent: :destroy
   has_many :members, through: :participations, source: :user
   belongs_to :owner, class_name: 'User', foreign_key: :owner_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
                             dependent: :destroy
   has_many :invitations, dependent: :destroy
   has_many :invitation_projects, through: :invitations, source: :project
+  has_many :participations, dependent: :destroy
+  has_many :member_projects, through: :participations, source: :project
 
   has_one_attached :image
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,14 @@ class User < ApplicationRecord
     invitations.count
   end
 
+  def participate_in(project)
+    participations.build(project: project).save
+  end
+
+  def member?(project)
+    participations.exists?(project_id: project.id)
+  end
+
   # include RemoteFileAttachable
   def attachment_target
     image

--- a/app/validators/member_rejection_validator.rb
+++ b/app/validators/member_rejection_validator.rb
@@ -1,0 +1,8 @@
+class MemberRejectionValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value.member?(record.project)
+
+    record.errors[attribute] <<
+      (options[:message] || I18n.t('errors.messages.invalid'))
+  end
+end

--- a/app/validators/owner_rejection_validator.rb
+++ b/app/validators/owner_rejection_validator.rb
@@ -1,0 +1,8 @@
+class OwnerRejectionValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value.owner?(record.project)
+
+    record.errors[attribute] <<
+      (options[:message] || I18n.t('errors.messages.invalid'))
+  end
+end

--- a/app/views/cards/_form.html.slim
+++ b/app/views/cards/_form.html.slim
@@ -20,7 +20,7 @@
               .col-12.col-md-6
                 .form-group
                   = f.label :assignee_id
-                  = f.collection_select :assignee_id, User.all, :id, :name, { selected: card.assignee.id }, class: 'form-control form-control-lg'
+                  = f.collection_select :assignee_id, project.accessible_users, :id, :name, { selected: card.assignee.id }, class: 'form-control form-control-lg'
 
             - if card.new_record?
               = f.submit '作成', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple mt-4 width-200px'

--- a/app/views/invitations/_form.html.slim
+++ b/app/views/invitations/_form.html.slim
@@ -1,4 +1,4 @@
-= form_with model: form, url: project_invitations_path(project), scope: :invitation, method: :get, local: true do |f|
+= form_with model: form, url: project_generate_invitaions_path(project), scope: :invitation, method: :get, local: true do |f|
 
   p.mb-2 ユーザを検索
   .row

--- a/app/views/invitations/_users.html.slim
+++ b/app/views/invitations/_users.html.slim
@@ -13,5 +13,8 @@
         - elsif user.invited?(project)
           .col-auto.width-120px.text-middle-purple.text-center.ml-1.mt-1.mt-sm-0 招待済み
 
+        - elsif user.member?(project)
+          .col-auto.width-120px.text-middle-purple.text-center.ml-1.mt-1.mt-sm-0 参加済み
+
         - else
           = link_to '招待', project_invitations_path(project, { user_id: user.id }), method: :post, class: 'col-auto btn btn-lg btn-outline-secondary border-middle-purple text-middle-purple width-120px ml-1 mt-1 mt-sm-0'

--- a/app/views/notifications/_notifications.html.slim
+++ b/app/views/notifications/_notifications.html.slim
@@ -3,4 +3,4 @@
     .row.align-items-center.my-0.my-md-1
       .col #{invitation.project.owner.name}さんがあなたをプロジェクト「#{invitation.project.name}」に招待しています
       .col-auto
-        = link_to '参加', '#', class: 'btn btn-outline-secondary bg-light-purple text-middle-purple'
+        = link_to '参加', project_participations_path(invitation.project), method: :post, class: 'btn btn-outline-secondary bg-light-purple text-middle-purple'

--- a/app/views/projects/_projects.html.slim
+++ b/app/views/projects/_projects.html.slim
@@ -11,8 +11,9 @@
       .collapse.text-center id="js-collapse_#{project.id}"
         p.m-0
           = link_to 'プロジェクトを見る', project_path(project), class: 'btn btn-lg btn-outline-secondary border-middle-purple bg-light-purple text-purple mt-2'
-        p.m-0
-          = link_to 'プロジェクトの設定', edit_myproject_path(project), class: 'btn btn-lg btn-outline-secondary border-middle-purple bg-light-purple text-purple mt-2'
+        - if current_user.owner?(project)
+          p.m-0
+            = link_to 'プロジェクトの設定', edit_myproject_path(project), class: 'btn btn-lg btn-outline-secondary border-middle-purple bg-light-purple text-purple mt-2'
 
     - else
       .card.border-middle-purple.bg-white-purple.text-secondary-purple.height-150px

--- a/app/views/projects/_projects.html.slim
+++ b/app/views/projects/_projects.html.slim
@@ -1,7 +1,7 @@
 - projects.each do |project|
   .col-12.col-sm-6.col-lg-4.mt-4
 
-    - if project.accessible?(current_user)
+    - if current_user.owner?(project)
       a.link-unstyled data-toggle='collapse' href="#js-collapse_#{project.id}" role='button' aria-expanded='false' aria-controls="js-collapse_#{project.id}"
         .card.btn.btn-outline-secondary.border-middle-purple.bg-light-purple.text-purple.button-text-wrap.height-150px
           .card-body.overflow-scroll
@@ -14,6 +14,13 @@
         - if current_user.owner?(project)
           p.m-0
             = link_to 'プロジェクトの設定', edit_myproject_path(project), class: 'btn btn-lg btn-outline-secondary border-middle-purple bg-light-purple text-purple mt-2'
+
+    - elsif current_user.member?(project)
+      = link_to project_path(project), class: 'link-unstyled' do
+        .card.btn.btn-outline-secondary.border-middle-purple.bg-light-purple.text-purple.button-text-wrap.height-150px
+          .card-body.overflow-scroll
+            .card-text.h4.mt-4
+              = project.name
 
     - else
       .card.border-middle-purple.bg-white-purple.text-secondary-purple.height-150px

--- a/app/views/projects/info.html.slim
+++ b/app/views/projects/info.html.slim
@@ -1,0 +1,25 @@
+.row
+  .col-12.col-md-10.mx-auto.mt-4
+    .card.border-middle-purple.text-purple
+      .card-header.h3.bg-light-purple.pl-md-5 プロジェクト情報
+      .card-body.p-md-5
+        .card-text.h5
+          .row.h4
+            .col-auto = @project.name
+          .row.h6.py-3.border-bottom
+            .col-auto = simple_format(@project.summary)
+
+          .row.mt-4.align-items-center.text-middle-purple
+            .col-auto = image_tag @project.owner.image, class: 'size35x35 rounded-circle'
+            .col-5.col-md-4.col-lg-3.px-0.h4.mb-0 = @project.owner.name
+            .col-auto.width-120px.text-center.font-weight-bold.ml-1.mt-1.mt-sm-0 オーナー
+          
+          - @project.members.each do |member|
+            .row.mt-4.align-items-center.text-middle-purple
+              .col-auto = image_tag member.image, class: 'size35x35 rounded-circle'
+              .col-5.col-md-4.col-lg-3.px-0.h4.mb-0 = member.name
+              .col-auto.width-120px.text-center.ml-1.mt-1.mt-sm-0 メンバー
+
+          = link_to project_path(@project), class: 'text-middle-purple link-unstyled float-right mt-5 mt-lg-0' do
+            i.fas.fa-link.mr-1
+            |プロジェクトに戻る

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -1,13 +1,20 @@
 .row
-  .col-md-7.col-lg-8.col-xl-9.overflow-scroll
+  .col-xl-7.overflow-scroll
     .h4.text-middle-purple = @project.name
 
-  .col-md-5.col-lg-4.col-xl-3.text-right.pr-3
-    = link_to 'ログを見る', '#', class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-2'
+  .col-xl-5.text-right
+    = link_to project_info_path(@project), class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-1 width-100px' do
+      i.fas.fa-info-circle.fa-lg.mr-1
+      |情報
+    = link_to '#', class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-1 width-100px' do
+      i.far.fa-file-alt.fa-lg.mr-1
+      |ログ
     - if current_user.owner?(@project)
-      = link_to 'ユーザを招待', project_invite_path(@project), class: 'btn btn-outline-secondary border-middle-purple text-middle-purple'
+      = link_to project_invite_path(@project), class: 'btn btn-outline-secondary border-middle-purple text-middle-purple width-100px' do
+        i.fas.fa-user-friends.fa-lg.mr-1
+        |招待
 
-.row.mt-4.text-middle-purple.row-scroll-x.w-100.pb-2
+.row.mt-5.text-middle-purple.row-scroll-x.w-100.pb-2
 
   - @project.columns.each do |column|
     = render 'column', project: @project, column: column

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   # 全プロジェクト
   resources :projects, only: %i[index show] do
+    get 'info', to: 'projects#info'
     resources :columns, only: %i[new create edit update destroy] do
       get 'previous', on: :member
       get 'next', on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,8 @@ Rails.application.routes.draw do
     # 招待
     controller :invitations do
       get 'invite', action: :invite
-      resources :invitations, only: %i[index create]
+      get 'generate_invitaions', action: :generate_invitaions
+      resources :invitations, only: %i[create]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,9 @@ Rails.application.routes.draw do
       get 'generate_invitaions', action: :generate_invitaions
       resources :invitations, only: %i[create]
     end
+
+    # 参加
+    resources :participations, only: %i[create]
   end
 
   # マイプロジェクト

--- a/db/migrate/20190621060653_create_participations.rb
+++ b/db/migrate/20190621060653_create_participations.rb
@@ -1,0 +1,11 @@
+class CreateParticipations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :participations do |t|
+      t.references :project, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
+
+      t.timestamps
+    end
+    add_index :participations, [:project_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_041931) do
+ActiveRecord::Schema.define(version: 2019_06_21_060653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,16 @@ ActiveRecord::Schema.define(version: 2019_06_19_041931) do
     t.index ["user_id"], name: "index_invitations_on_user_id"
   end
 
+  create_table "participations", force: :cascade do |t|
+    t.bigint "project_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "user_id"], name: "index_participations_on_project_id_and_user_id", unique: true
+    t.index ["project_id"], name: "index_participations_on_project_id"
+    t.index ["user_id"], name: "index_participations_on_user_id"
+  end
+
   create_table "projects", force: :cascade do |t|
     t.string "name", null: false
     t.text "summary"
@@ -97,5 +107,7 @@ ActiveRecord::Schema.define(version: 2019_06_19_041931) do
   add_foreign_key "columns", "projects"
   add_foreign_key "invitations", "projects"
   add_foreign_key "invitations", "users"
+  add_foreign_key "participations", "projects"
+  add_foreign_key "participations", "users"
   add_foreign_key "projects", "users", column: "owner_id"
 end

--- a/spec/factories/participations.rb
+++ b/spec/factories/participations.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :participation do
+    association :project
+    association :user
+  end
+end

--- a/spec/models/participation_spec.rb
+++ b/spec/models/participation_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Participation, type: :model do
+  describe '#destroy_invitation!' do
+    let(:user) { create(:user) }
+    let(:project) { create(:project) }
+
+    context 'ユーザがプロジェクトに招待されている場合' do
+      before { Invitation.create(user: user, project: project) }
+
+      it 'プロジェクトに参加すると招待が削除されること' do
+        expect { Participation.create(user: user, project: project) }
+          .to change { Invitation.count }.from(1).to(0)
+      end
+    end
+
+    context 'ユーザがプロジェクトに招待されていない場合' do
+      it 'プロジェクトに参加してもエラーが起きないこと' do
+        # プロジェクト参加方法を限定しないため、招待されていないプロジェクトに参加しても、
+        # モデルではエラーにしない。
+        # なお、アプリケーションのお知らせ画面からのプロジェクト参加では、
+        # ParticipationsControllerで招待済みのプロジェクトのみ処理対象にするため、
+        # 招待されていないプロジェクトに参加しようとすると404エラーになる。
+        expect { Participation.create(user: user, project: project) }
+          .not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -118,10 +118,6 @@ RSpec.describe Project, type: :model do
       context 'pageがnilの場合' do
         let(:results) { Project.for_accessible_list_second_page_or_later(user, nil) }
 
-        it '件数が正しいこと' do
-          expect(results.count).to eq 0
-        end
-
         it '内容が正しいこと' do
           expect(results).to eq []
         end
@@ -130,10 +126,6 @@ RSpec.describe Project, type: :model do
       context "pageが'1'（文字）の場合" do
         let(:results) { Project.for_accessible_list_second_page_or_later(user, '1') }
 
-        it '件数が正しいこと' do
-          expect(results.count).to eq 0
-        end
-
         it '内容が正しいこと' do
           expect(results).to eq []
         end
@@ -141,10 +133,6 @@ RSpec.describe Project, type: :model do
 
       context 'pageが1（数値）の場合' do
         let(:results) { Project.for_accessible_list_second_page_or_later(user, 1) }
-
-        it '件数が正しいこと' do
-          expect(results.count).to eq 0
-        end
 
         it '内容が正しいこと' do
           expect(results).to eq []

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -29,42 +29,41 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe '.for_myprojects_list' do
+  describe '.for_accessible_list' do
     let(:user) { create(:user) }
 
     before do
-      allow(Project).to receive(:for_myprojects_first_page)
-      allow(Project).to receive(:for_myprojects_second_page_or_later)
+      allow(Project).to receive(:for_accessible_list_first_page)
+      allow(Project).to receive(:for_accessible_list_second_page_or_later)
     end
 
     context '1ページ目の場合' do
-      it '.for_myprojects_first_pageを呼び出すこと' do
-        Project.for_myprojects_list(user, nil)
-        expect(Project).to have_received(:for_myprojects_first_page).once
-        expect(Project).not_to have_received(:for_myprojects_second_page_or_later)
+      it '.for_accessible_list_first_pageを呼び出すこと' do
+        Project.for_accessible_list(user, nil)
+        expect(Project).to have_received(:for_accessible_list_first_page).once
+        expect(Project).not_to have_received(:for_accessible_list_second_page_or_later)
       end
     end
 
     context '2ページ目以降の場合' do
-      it '.for_myprojects_second_page_or_laterを呼び出すこと' do
-        Project.for_myprojects_list(user, 2)
-        expect(Project).to have_received(:for_myprojects_second_page_or_later).once
-        expect(Project).not_to have_received(:for_myprojects_first_page)
+      it '.for_accessible_list_second_page_or_laterを呼び出すこと' do
+        Project.for_accessible_list(user, 2)
+        expect(Project).to have_received(:for_accessible_list_second_page_or_later).once
+        expect(Project).not_to have_received(:for_accessible_list_first_page)
       end
     end
   end
 
-  describe '.for_myprojects_first_page' do
+  describe '.for_accessible_list_first_page' do
     let(:user) { create(:user) }
-    let(:results) { Project.for_myprojects_first_page(user) }
+    let(:results) { Project.for_accessible_list_first_page(user) }
 
     context '該当のデータが存在する場合' do
       before do
         (1..3).each { |n| create(:project, name: "Project_#{n}", owner: user) }
-        create(:project)
       end
 
-      it '結果が正しいこと' do
+      it '件数が正しいこと' do
         expect(results.count).to eq 3
       end
 
@@ -74,28 +73,25 @@ RSpec.describe Project, type: :model do
     end
 
     context '該当のデータが存在しない場合' do
-      before do
-        create(:project)
-      end
+      before { create(:project) }
 
-      it '結果が正しいこと' do
+      it '件数が正しいこと' do
         expect(results.count).to eq 0
       end
     end
   end
 
-  describe '.for_myprojects_second_page_or_later' do
+  describe '.for_accessible_list_second_page_or_later' do
     let(:user) { create(:user) }
 
     context '該当のデータが存在する場合' do
-      let(:results) { Project.for_myprojects_second_page_or_later(user, 2) }
+      let(:results) { Project.for_accessible_list_second_page_or_later(user, 2) }
 
       before do
         (1..12).each { |n| create(:project, name: "Project_#{n}", owner: user) }
-        create_list(:project, 2)
       end
 
-      it '結果が正しいこと' do
+      it '件数が正しいこと' do
         # 該当が全12件、1ページあたり9件だがpaddingが-1なので、1ページ目8件で2ページ目は4件
         expect(results.count).to eq 4
       end
@@ -107,26 +103,22 @@ RSpec.describe Project, type: :model do
     end
 
     context '該当のデータが存在しない場合' do
-      let(:results) { Project.for_myprojects_second_page_or_later(user, 2) }
+      let(:results) { Project.for_accessible_list_second_page_or_later(user, 2) }
 
-      before do
-        create_list(:project, 12)
-      end
+      before { create_list(:project, 12) }
 
-      it '結果が正しいこと' do
+      it '件数が正しいこと' do
         expect(results.count).to eq 0
       end
     end
 
     context '1ページ目が指定された場合' do
-      before do
-        create_list(:project, 12, owner: user)
-      end
+      before { create_list(:project, 12, owner: user) }
 
       context 'pageがnilの場合' do
-        let(:results) { Project.for_myprojects_second_page_or_later(user, nil) }
+        let(:results) { Project.for_accessible_list_second_page_or_later(user, nil) }
 
-        it '結果が正しいこと' do
+        it '件数が正しいこと' do
           expect(results.count).to eq 0
         end
 
@@ -136,9 +128,9 @@ RSpec.describe Project, type: :model do
       end
 
       context "pageが'1'（文字）の場合" do
-        let(:results) { Project.for_myprojects_second_page_or_later(user, '1') }
+        let(:results) { Project.for_accessible_list_second_page_or_later(user, '1') }
 
-        it '結果が正しいこと' do
+        it '件数が正しいこと' do
           expect(results.count).to eq 0
         end
 
@@ -148,9 +140,9 @@ RSpec.describe Project, type: :model do
       end
 
       context 'pageが1（数値）の場合' do
-        let(:results) { Project.for_myprojects_second_page_or_later(user, 1) }
+        let(:results) { Project.for_accessible_list_second_page_or_later(user, 1) }
 
-        it '結果が正しいこと' do
+        it '件数が正しいこと' do
           expect(results.count).to eq 0
         end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -153,9 +153,119 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  # TODO: ユーザ招待機能を作成後にaccessible実装してテストも作成すること
-  describe '.accessible'
-  describe '#accessible?'
+  describe '.accessible' do
+    let(:results) { Project.accessible(user) }
+    let(:user) { create(:user) }
+
+    context '該当のデータが存在する場合' do
+      context 'ユーザがプロジェクトのオーナーの場合' do
+        before { create(:project, owner: user) }
+
+        it '件数が正しいこと' do
+          expect(results.count).to eq 1
+        end
+
+        it '内容が正しいこと' do
+          expect(user.owner?(results.first)).to be_truthy
+        end
+      end
+
+      context 'ユーザがプロジェクトのメンバーの場合' do
+        before do
+          project = create(:project)
+          user.participate_in(project)
+        end
+
+        it '件数が正しいこと' do
+          expect(results.count).to eq 1
+        end
+
+        it '内容が正しいこと' do
+          expect(user.member?(results.first)).to be_truthy
+        end
+      end
+    end
+
+    context '該当のデータが存在しない場合' do
+      before do
+        # 無関係のプロジェクト
+        create(:project)
+        # 招待プロジェクト
+        create(:invitation, user: user)
+      end
+
+      it '件数が正しいこと' do
+        expect(results.count).to eq 0
+      end
+    end
+  end
+
+  describe '.owned_by' do
+    let(:results) { Project.owned_by(user) }
+    let(:user) { create(:user) }
+
+    context '該当のデータが存在する場合' do
+      before { create(:project, owner: user) }
+
+      it '件数が正しいこと' do
+        expect(results.count).to eq 1
+      end
+
+      it '内容が正しいこと' do
+        expect(user.owner?(results.first)).to be_truthy
+      end
+    end
+
+    context '該当のデータが存在しない場合' do
+      before do
+        # 無関係のプロジェクト
+        create(:project)
+        # 招待プロジェクト
+        create(:invitation, user: user)
+        # 参加プロジェクト
+        create(:participation, user: user)
+      end
+
+      it '件数が正しいこと' do
+        expect(results.count).to eq 0
+      end
+    end
+  end
+
+  describe '.participated_in_by' do
+    let(:results) { Project.participated_in_by(user) }
+    let(:user) { create(:user) }
+
+    context '該当のデータが存在する場合' do
+      before do
+        project = create(:project)
+        user.participate_in(project)
+      end
+
+      it '件数が正しいこと' do
+        expect(results.count).to eq 1
+      end
+
+      it '内容が正しいこと' do
+        expect(user.member?(results.first)).to be_truthy
+      end
+    end
+
+    context '該当のデータが存在しない場合' do
+      before do
+        # 無関係のプロジェクト
+        create(:project)
+        # 招待プロジェクト
+        create(:invitation, user: user)
+        # オーナーのプロジェクト
+        create(:project, owner: user)
+      end
+
+      it '件数が正しいこと' do
+        expect(results.count).to eq 0
+      end
+    end
+  end
 
   describe '#invite' do
     let(:user) { create(:user) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -267,6 +267,49 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe '#accessible?' do
+    subject { project.accessible?(user) }
+    let(:user) { create(:user) }
+
+    context 'ユーザがアクセス可能なプロジェクトの場合' do
+      context 'ユーザがプロジェクトのオーナーの場合' do
+        let(:project) { create(:project, owner: user) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_truthy
+        end
+      end
+
+      context 'ユーザがプロジェクトのメンバーの場合' do
+        let(:project) { create(:project) }
+        before { user.participate_in(project) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_truthy
+        end
+      end
+    end
+
+    context 'ユーザがアクセス不可能なプロジェクトの場合' do
+      context 'ユーザが招待されているプロジェクトの場合' do
+        let(:project) { create(:project) }
+        before { project.invite(user) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsy
+        end
+      end
+
+      context 'ユーザが無関係のプロジェクトの場合' do
+        let(:project) { create(:project) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsy
+        end
+      end
+    end
+  end
+
   describe '#invite' do
     let(:user) { create(:user) }
     let(:project) { create(:project) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -324,4 +324,47 @@ RSpec.describe Project, type: :model do
       expect(project.invitations.first.user).to eq user
     end
   end
+
+  describe '#accessible_users' do
+    let(:results) { project.accessible_users }
+    let(:project) { create(:project) }
+
+    context 'プロジェクトにオーナーだけがいる場合' do
+      it '件数が正しいこと' do
+        expect(results.count).to eq 1
+      end
+
+      it '内容が正しいこと' do
+        expect(results.first).to eq project.owner
+      end
+    end
+
+    context 'プロジェクトにメンバーがいる場合' do
+      let(:members) { create_list(:user, 2) }
+      before { members.each { |m| m.participate_in(project) } }
+
+      it '件数が正しいこと' do
+        expect(results.count).to eq 3
+      end
+
+      it '内容が正しいこと' do
+        expect(results.first).to eq project.owner
+        expect(results).to include(*members)
+      end
+    end
+
+    context '該当しないユーザがいる場合' do
+      let!(:invitee) { create(:user) }
+      let!(:outsider) { create(:user) }
+      before { project.invite(invitee) }
+
+      it '件数が正しいこと' do
+        expect(results.count).to eq 1
+      end
+
+      it '内容が正しいこと' do
+        expect(results.first).to eq project.owner
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'owner?' do
+  describe '#owner?' do
     subject { user.owner?(project) }
     let(:user) { create(:user) }
 
@@ -133,8 +133,26 @@ RSpec.describe User, type: :model do
     context 'ユーザがプロジェクトのオーナーでない場合' do
       let(:project) { create(:project) }
 
-      it '結果が正しいこと' do
-        is_expected.to be_falsey
+      context 'ユーザがプロジェクトに招待されている場合' do
+        before { project.invite(user) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
+      end
+
+      context 'ユーザがプロジェクトのメンバーの場合' do
+        before { user.participate_in(project) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
+      end
+
+      context 'ユーザがプロジェクトと無関係の場合' do
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
       end
     end
   end
@@ -142,12 +160,10 @@ RSpec.describe User, type: :model do
   describe '#invited?' do
     subject { user.invited?(project) }
     let(:user) { create(:user) }
-    let(:project) { create(:project) }
 
     context 'ユーザがプロジェクトに招待されている場合' do
-      before do
-        project.invite(user)
-      end
+      let(:project) { create(:project) }
+      before { project.invite(user) }
 
       it '結果が正しいこと' do
         is_expected.to be_truthy
@@ -155,8 +171,28 @@ RSpec.describe User, type: :model do
     end
 
     context 'ユーザがプロジェクトに招待されていない場合' do
-      it '結果が正しいこと' do
-        is_expected.to be_falsey
+      context 'ユーザがプロジェクトのオーナーの場合' do
+        let(:project) { create(:project, owner: user) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
+      end
+      context 'ユーザがプロジェクトに参加している場合' do
+        let(:project) { create(:project) }
+        before { user.participate_in(project) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
+      end
+
+      context 'ユーザがプロジェクトと無関係の場合' do
+        let(:project) { create(:project) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -186,6 +186,21 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#participate_in' do
+    let(:user) { create(:user) }
+    let(:project) { create(:project) }
+
+    it '結果が正しいこと' do
+      expect(user.participate_in(project)).to be_truthy
+    end
+
+    it '内容が正しいこと' do
+      expect { user.participate_in(project) }
+        .to change { user.participations.count }.from(0).to(1)
+      expect(user.participations.first.user).to eq user
+    end
+  end
+
   # include RemoteFileAttachable
   it_behaves_like 'remote_file_attachable'
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -201,6 +201,47 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#member?' do
+    subject { user.member?(project) }
+    let(:user) { create(:user) }
+
+    context 'ユーザがプロジェクトのメンバーの場合' do
+      let(:project) { create(:project) }
+      before { user.participate_in(project) }
+
+      it '結果が正しいこと' do
+        is_expected.to be_truthy
+      end
+    end
+
+    context 'ユーザがプロジェクトのメンバーではない場合' do
+      context 'ユーザがプロジェクトオーナーの場合' do
+        let(:project) { create(:project, owner: user) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
+      end
+
+      context 'ユーザがプロジェクトに招待されている場合' do
+        let(:project) { create(:project) }
+        before { project.invite(user) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
+      end
+
+      context 'ユーザがプロジェクトと無関係の場合' do
+        let(:project) { create(:project) }
+
+        it '結果が正しいこと' do
+          is_expected.to be_falsey
+        end
+      end
+    end
+  end
+
   # include RemoteFileAttachable
   it_behaves_like 'remote_file_attachable'
 end

--- a/spec/validators/member_rejection_validator_spec.rb
+++ b/spec/validators/member_rejection_validator_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe MemberRejectionValidator, type: :validator do
+  let(:model_class) do
+    Struct.new(:user, :project) do
+      include ActiveModel::Validations
+      validates :user, member_rejection: true
+    end
+  end
+
+  describe '#validate_each' do
+    let(:model) { model_class.new(user, project) }
+    let(:user) { create(:user) }
+    let(:project) { create(:project) }
+
+    context 'ユーザがプロジェクトのメンバーでない場合' do
+      it '結果が正しいこと' do
+        expect(model).to be_valid
+      end
+    end
+
+    context 'ユーザがプロジェクトのメンバーの場合' do
+      before do
+        user.participate_in(project)
+      end
+
+      it '結果が正しいこと' do
+        expect(model).to be_invalid
+      end
+
+      it 'エラーメッセージが正しいこと' do
+        model.validate
+        expect(model.errors[:user]).to eq ['は不正な値です']
+      end
+    end
+  end
+end

--- a/spec/validators/owner_rejection_validator_spec.rb
+++ b/spec/validators/owner_rejection_validator_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe OwnerRejectionValidator, type: :validator do
+  let(:model_class) do
+    Struct.new(:user, :project) do
+      include ActiveModel::Validations
+      validates :user, owner_rejection: true
+    end
+  end
+
+  describe '#validate_each' do
+    let(:model) { model_class.new(user, project) }
+    let(:user) { create(:user) }
+
+    context 'ユーザがプロジェクトのオーナーでない場合' do
+      let(:project) { create(:project) }
+
+      it '結果が正しいこと' do
+        expect(model).to be_valid
+      end
+    end
+
+    context 'ユーザがプロジェクトのオーナーの場合' do
+      let(:project) { create(:project, owner: user) }
+
+      it '結果が正しいこと' do
+        expect(model).to be_invalid
+      end
+
+      it 'エラーメッセージが正しいこと' do
+        model.validate
+        expect(model.errors[:user]).to eq ['は不正な値です']
+      end
+    end
+  end
+end


### PR DESCRIPTION
ref #21 
参加機能を作成しました。
- participationモデルを作成
- お知らせ画面から「参加」押下するとプロジェクトに参加できるように、ParticipationsController#createアクションを設定
- userモデルの#participate_in(project)メソッドにプロジェクト参加機能を作成
- participationモデルのbefore_createコールバックに招待を削除する機能を作成

招待と参加でエラーになるパターンは以下です。

招待 |  
-- | --
自分がオーナーでないプロジェクトに招待 | Invitationsコントローラの404エラー
オーナーを招待 | 招待モデルのバリデーションエラー
すでに招待されているユーザを招待 | 招待モデルのバリデーションエラー
すでに参加しているユーザを招待 | 招待モデルのバリデーションエラー

参加 |  
-- | --
自分が招待されていないプロジェクトに参加 | Participationsコントローラの404エラー
オーナーが参加 | 参加モデルのバリデーションエラー
すでに参加しているユーザが参加 | 参加モデルのバリデーションエラー