### PR TITLE
ログ機能を作成

### DIFF
--- a/app/callbacks/card_create_logs_callbacks.rb
+++ b/app/callbacks/card_create_logs_callbacks.rb
@@ -1,0 +1,15 @@
+class CardCreateLogsCallbacks
+  def content(card)
+    if card.operator
+      "#{card.operator.name}さんが#{card.name}カードを作成しました"
+    else
+      "#{card.name}カードが作成されました"
+    end
+  end
+
+  private
+
+  def after_create(card)
+    Log.create!(content: content(card), project: card.project)
+  end
+end

--- a/app/callbacks/card_destroy_logs_callbacks.rb
+++ b/app/callbacks/card_destroy_logs_callbacks.rb
@@ -1,0 +1,15 @@
+class CardDestroyLogsCallbacks
+  def content(card)
+    if card.operator
+      "#{card.operator.name}さんが#{card.name}カードを削除しました"
+    else
+      "#{card.column.name}カラムの#{card.name}カードが削除されました"
+    end
+  end
+
+  private
+
+  def after_destroy(card)
+    Log.create!(content: content(card), project: card.project)
+  end
+end

--- a/app/callbacks/card_save_logs_callbacks.rb
+++ b/app/callbacks/card_save_logs_callbacks.rb
@@ -1,0 +1,31 @@
+class CardSaveLogsCallbacks
+  TARGET_ATTRIBUTES = %w[due_date assignee_id].freeze
+
+  def content_for_due_date(card)
+    due_date_str = card.due_date ? I18n.l(card.due_date, format: :yyyymmdd) : 'なし'
+    if card.operator
+      "#{card.operator.name}さんが#{card.name}カードの期限を#{due_date_str}に設定しました"
+    else
+      "#{card.name}カードの期限が#{due_date_str}に設定されました"
+    end
+  end
+
+  def content_for_assignee_id(card)
+    if card.operator
+      "#{card.operator.name}さんが#{card.name}カードを#{card.assignee.name}さんにアサインしました"
+    else
+      "#{card.name}カードが#{card.assignee.name}さんにアサインされました"
+    end
+  end
+
+  private
+
+  def after_save(card)
+    TARGET_ATTRIBUTES.each do |attr|
+      next unless card.saved_change_to_attribute?(attr)
+
+      content = send("content_for_#{attr}", card)
+      Log.create!(content: content, project: card.project)
+    end
+  end
+end

--- a/app/callbacks/card_update_logs_callbacks.rb
+++ b/app/callbacks/card_update_logs_callbacks.rb
@@ -1,0 +1,17 @@
+class CardUpdateLogsCallbacks
+  def content(card)
+    if card.operator
+      "#{card.operator.name}さんが#{card.name_before_last_save}カードの名前を#{card.name}に編集しました"
+    else
+      "#{card.name_before_last_save}カードの名前が#{card.name}に編集されました"
+    end
+  end
+
+  private
+
+  def after_update(card)
+    return unless card.saved_change_to_name?
+
+    Log.create!(content: content(card), project: card.project)
+  end
+end

--- a/app/callbacks/column_create_logs_callbacks.rb
+++ b/app/callbacks/column_create_logs_callbacks.rb
@@ -1,0 +1,15 @@
+class ColumnCreateLogsCallbacks
+  def content(column)
+    if column.operator
+      "#{column.operator.name}さんが#{column.name}カラムを作成しました"
+    else
+      "#{column.name}カラムが作成されました"
+    end
+  end
+
+  private
+
+  def after_create(column)
+    Log.create!(content: content(column), project: column.project)
+  end
+end

--- a/app/callbacks/column_destroy_logs_callbacks.rb
+++ b/app/callbacks/column_destroy_logs_callbacks.rb
@@ -1,0 +1,15 @@
+class ColumnDestroyLogsCallbacks
+  def content(column)
+    if column.operator
+      "#{column.operator.name}さんが#{column.name}カラムを削除しました"
+    else
+      "#{column.name}カラムが削除されました"
+    end
+  end
+
+  private
+
+  def after_destroy(column)
+    Log.create!(content: content(column), project: column.project)
+  end
+end

--- a/app/callbacks/column_update_logs_callbacks.rb
+++ b/app/callbacks/column_update_logs_callbacks.rb
@@ -1,0 +1,17 @@
+class ColumnUpdateLogsCallbacks
+  def content(column)
+    if column.operator
+      "#{column.operator.name}さんが#{column.name_before_last_save}カラムの名前を#{column.name}に編集しました"
+    else
+      "#{column.name_before_last_save}カラムの名前が#{column.name}に編集されました"
+    end
+  end
+
+  private
+
+  def after_update(column)
+    return unless column.saved_change_to_name?
+
+    Log.create!(content: content(column), project: column.project)
+  end
+end

--- a/app/callbacks/invitation_create_logs_callbacks.rb
+++ b/app/callbacks/invitation_create_logs_callbacks.rb
@@ -1,0 +1,11 @@
+class InvitationCreateLogsCallbacks
+  def content(invitation)
+    "#{invitation.project.owner.name}さんが#{invitation.user.name}さんをこのプロジェクトに招待しました"
+  end
+
+  private
+
+  def after_create(invitation)
+    Log.create!(content: content(invitation), project: invitation.project)
+  end
+end

--- a/app/callbacks/participation_create_logs_callbacks.rb
+++ b/app/callbacks/participation_create_logs_callbacks.rb
@@ -1,0 +1,11 @@
+class ParticipationCreateLogsCallbacks
+  def content(participation)
+    "#{participation.user.name}さんがこのプロジェクトに参加しました"
+  end
+
+  private
+
+  def after_create(participation)
+    Log.create!(content: content(participation), project: participation.project)
+  end
+end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -2,6 +2,7 @@ class CardsController < ApplicationController
   before_action :set_project
   before_action :set_column
   before_action :set_card, only: %i[edit update destroy previous next]
+  before_action :set_operator, only: %i[update destroy]
 
   def new
     @card = @column.cards.build
@@ -11,6 +12,7 @@ class CardsController < ApplicationController
   def create
     @card = @column.cards.build(card_params)
     @card.project = @project
+    @card.operator = current_user
 
     if @card.save
       redirect_to project_path(@project), notice: 'カードを作成しました'
@@ -61,5 +63,9 @@ class CardsController < ApplicationController
 
   def set_card
     @card = @column.cards.find(params[:id])
+  end
+
+  def set_operator
+    @card.operator = current_user
   end
 end

--- a/app/controllers/columns_controller.rb
+++ b/app/controllers/columns_controller.rb
@@ -1,6 +1,7 @@
 class ColumnsController < ApplicationController
   before_action :set_project
   before_action :set_column, only: %i[edit update destroy previous next]
+  before_action :set_operator, only: %i[update destroy]
 
   def new
     @column = @project.columns.build
@@ -8,6 +9,7 @@ class ColumnsController < ApplicationController
 
   def create
     @column = @project.columns.build(column_params)
+    @column.operator = current_user
 
     if @column.save
       redirect_to project_path(@project), notice: 'カラムを作成しました'
@@ -54,5 +56,9 @@ class ColumnsController < ApplicationController
 
   def set_column
     @column = @project.columns.find(params[:id])
+  end
+
+  def set_operator
+    @column.operator = current_user
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,0 +1,6 @@
+class LogsController < ApplicationController
+  def index
+    @project = Project.accessible(current_user).find(params[:project_id])
+    @logs = @project.logs.order(created_at: :desc).page(params[:page])
+  end
+end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -5,6 +5,8 @@ class Card < ApplicationRecord
 
   acts_as_list scope: %i[project_id column_id]
 
+  attr_accessor :operator
+
   validates :name, presence: true,
                    uniqueness: { scope: :project },
                    length: { maximum: 40 }

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -12,6 +12,11 @@ class Card < ApplicationRecord
                    length: { maximum: 40 }
   validate :verify_assignee
 
+  after_create CardCreateLogsCallbacks.new
+  after_save CardSaveLogsCallbacks.new
+  after_update CardUpdateLogsCallbacks.new
+  after_destroy CardDestroyLogsCallbacks.new
+
   def move_to_higher_column
     return false if column.first?
 

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -4,6 +4,8 @@ class Column < ApplicationRecord
 
   acts_as_list scope: :project
 
+  attr_accessor :operator
+
   validates :name, presence: true,
                    uniqueness: { scope: :project },
                    length: { maximum: 40 }

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -9,4 +9,8 @@ class Column < ApplicationRecord
   validates :name, presence: true,
                    uniqueness: { scope: :project },
                    length: { maximum: 40 }
+
+  after_create ColumnCreateLogsCallbacks.new
+  after_update ColumnUpdateLogsCallbacks.new
+  after_destroy ColumnDestroyLogsCallbacks.new
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -7,4 +7,6 @@ class Invitation < ApplicationRecord
   validates :user, uniqueness: { scope: :project }
   validates :user, owner_rejection: true
   validates :user, member_rejection: true
+
+  after_create InvitationCreateLogsCallbacks.new
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -2,4 +2,16 @@ class Log < ApplicationRecord
   belongs_to :project
 
   paginates_per 5
+
+  def self.create_due_date_notification_logs!
+    cards = Card.where('due_date <= ?', Date.today).order(created_at: :asc)
+    cards.each do |card|
+      content = if card.due_date.today?
+                  "本日が#{card.name}カードの締切期限です"
+                else
+                  "#{card.name}カードの締切期限が#{(Date.today - card.due_date).to_i}日過ぎました"
+                end
+      create!(content: content, project: card.project)
+    end
+  end
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,0 +1,3 @@
+class Log < ApplicationRecord
+  belongs_to :project
+end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,3 +1,5 @@
 class Log < ApplicationRecord
   belongs_to :project
+
+  paginates_per 5
 end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -6,6 +6,7 @@ class Participation < ApplicationRecord
   validates :user, owner_rejection: true
 
   before_create :destroy_invitation!, if: :invited?
+  after_create ParticipationCreateLogsCallbacks.new
 
   def invited?
     user.invited?(project)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,6 +5,7 @@ class Project < ApplicationRecord
   has_many :invitees, through: :invitations, source: :user
   has_many :participations, dependent: :destroy
   has_many :members, through: :participations, source: :user
+  has_many :logs, dependent: :destroy
   belongs_to :owner, class_name: 'User', foreign_key: :owner_id
 
   # プロジェクト一覧で1ページに表示するプロジェクトの個数

--- a/app/views/logs/_logs.html.slim
+++ b/app/views/logs/_logs.html.slim
@@ -1,0 +1,4 @@
+- logs.each do |log|
+  li.list-group-item.pl-md-5.pr-md-5.py-3.border-right-0.border-left-0.border-bottom-0
+    .row.my-0.my-md-1
+      .col = log.content

--- a/app/views/logs/_view_more.html.slim
+++ b/app/views/logs/_view_more.html.slim
@@ -1,0 +1,3 @@
+- unless logs.last_page?
+  .card-footer.text-center.bg-white
+    = link_to_next_page logs, 'もっと見る', class: 'btn btn-lg btn-outline-secondary border-middle-purple text-middle-purple width-250px', remote: true

--- a/app/views/logs/index.html.slim
+++ b/app/views/logs/index.html.slim
@@ -1,0 +1,23 @@
+.row
+  .col-12.col-md-10.mx-auto.mt-4
+    .card.border-middle-purple.text-purple
+      .card-header.h3.bg-light-purple.pl-md-5 #{@project.name}プロジェクト ログ
+
+      - if @logs.empty?
+        .card-body.pl-md-5
+          .card-text.h4 ログはありません
+
+      - else
+        ul.list-group.text-middle-purple.h4
+          #js-logs
+            = render 'logs', logs: @logs
+
+        #js-view_more
+          = render 'view_more', logs: @logs
+
+.row
+  .col-12.col-md-10.mx-auto.mt-5.h5
+    = link_to project_path(@project), class: 'text-middle-purple link-unstyled float-right' do
+      i.fas.fa-link.mr-1
+      |プロジェクトに戻る
+

--- a/app/views/logs/index.js.erb
+++ b/app/views/logs/index.js.erb
@@ -1,0 +1,9 @@
+<%# ログ一覧に新しいログを追加 %>
+var logs = document.getElementById('js-logs');
+var newLogs = "<%= j(render 'logs', logs: @logs) %>";
+logs.insertAdjacentHTML('beforeend', newLogs);
+
+<%# 「もっと見る」ボタンを書き換え %>
+var viewMore = document.getElementById('js-view_more');
+var newViewMore = "<%= j(render 'view_more', logs: @logs) %>";
+viewMore.innerHTML = newViewMore;

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -6,7 +6,7 @@
     = link_to project_info_path(@project), class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-1 width-100px' do
       i.fas.fa-info-circle.fa-lg.mr-1
       |情報
-    = link_to '#', class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-1 width-100px' do
+    = link_to project_logs_path(@project), class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-1 width-100px' do
       i.far.fa-file-alt.fa-lg.mr-1
       |ログ
     - if current_user.owner?(@project)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
 
   # 全プロジェクト
   resources :projects, only: %i[index show] do
-    get 'info', to: 'projects#info'
     resources :columns, only: %i[new create edit update destroy] do
       get 'previous', on: :member
       get 'next', on: :member
@@ -33,6 +32,12 @@ Rails.application.routes.draw do
 
     # 参加
     resources :participations, only: %i[create]
+
+    # 情報
+    get 'info', to: 'projects#info'
+
+    # ログ
+    resources :logs, only: %i[index]
   end
 
   # マイプロジェクト

--- a/db/migrate/20190625071508_create_logs.rb
+++ b/db/migrate/20190625071508_create_logs.rb
@@ -1,0 +1,10 @@
+class CreateLogs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :logs do |t|
+      t.text :content, null: false
+      t.references :project, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_21_060653) do
+ActiveRecord::Schema.define(version: 2019_06_25_071508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,14 @@ ActiveRecord::Schema.define(version: 2019_06_21_060653) do
     t.index ["user_id"], name: "index_invitations_on_user_id"
   end
 
+  create_table "logs", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "project_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_logs_on_project_id"
+  end
+
   create_table "participations", force: :cascade do |t|
     t.bigint "project_id", null: false
     t.bigint "user_id", null: false
@@ -107,6 +115,7 @@ ActiveRecord::Schema.define(version: 2019_06_21_060653) do
   add_foreign_key "columns", "projects"
   add_foreign_key "invitations", "projects"
   add_foreign_key "invitations", "users"
+  add_foreign_key "logs", "projects"
   add_foreign_key "participations", "projects"
   add_foreign_key "participations", "users"
   add_foreign_key "projects", "users", column: "owner_id"

--- a/lib/tasks/log_due_date.rake
+++ b/lib/tasks/log_due_date.rake
@@ -1,0 +1,6 @@
+namespace :log do
+  desc 'This task is called by the Heroku scheduler add-on'
+  task due_date: :environment do
+    Log.create_due_date_notification_logs!
+  end
+end

--- a/spec/callbacks/card_create_logs_callbacks_spec.rb
+++ b/spec/callbacks/card_create_logs_callbacks_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe CardCreateLogsCallbacks, type: :callback do
+  let(:user) { create(:user, name: '山田太郎') }
+  let(:project) { create(:project, owner: user) }
+  let(:column) { create(:column, project: project) }
+  let(:card) { build(:card, name: 'テスト', project: project, column: column) }
+
+  describe '#after_create' do
+    it '結果が正しいこと' do
+      expect { card.save }
+        .to change { Log.where('content LIKE(?)', '%カード%作成%').count }.by(1)
+    end
+  end
+
+  describe '#content' do
+    context '操作者が設定されている場合' do
+      before { card.operator = user }
+
+      it '内容が正しいこと' do
+        card.save
+        log = Log.where('content LIKE(?)', '%カード%作成%').last
+        expect(log.content).to eq '山田太郎さんがテストカードを作成しました'
+        expect(log.project).to eq project
+      end
+    end
+
+    context '操作者が設定されていない場合' do
+      it '内容が正しいこと' do
+        card.save
+        log = Log.where('content LIKE(?)', '%カード%作成%').last
+        expect(log.content).to eq 'テストカードが作成されました'
+        expect(log.project).to eq project
+      end
+    end
+  end
+end

--- a/spec/callbacks/card_destroy_logs_callbacks_spec.rb
+++ b/spec/callbacks/card_destroy_logs_callbacks_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe CardDestroyLogsCallbacks, type: :callback do
+  let(:user) { create(:user, name: '山田太郎') }
+  let(:project) { create(:project, owner: user) }
+  let(:column) { create(:column, name: 'サンプル', project: project) }
+  let(:card) { create(:card, name: 'テスト', project: project, column: column) }
+
+  describe '#after_destroy' do
+    it '結果が正しいこと' do
+      expect { card.destroy }
+        .to change { Log.where('content LIKE(?)', '%カード%削除%').count }.by(1)
+    end
+  end
+
+  describe '#content' do
+    context '操作者が設定されている場合' do
+      before { card.operator = user }
+
+      it '内容が正しいこと' do
+        card.destroy
+        log = Log.where('content LIKE(?)', '%カード%削除%').last
+        expect(log.content).to eq '山田太郎さんがテストカードを削除しました'
+        expect(log.project).to eq project
+      end
+    end
+
+    context '操作者が設定されていない場合' do
+      it '内容が正しいこと' do
+        card.destroy
+        log = Log.where('content LIKE(?)', '%カード%削除%').last
+        expect(log.content).to eq 'サンプルカラムのテストカードが削除されました'
+        expect(log.project).to eq project
+      end
+    end
+  end
+end

--- a/spec/callbacks/card_save_logs_callbacks_spec.rb
+++ b/spec/callbacks/card_save_logs_callbacks_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.describe CardSaveLogsCallbacks, type: :callback do
+  let(:user) { create(:user, name: '山田太郎') }
+  let(:project) { create(:project, owner: user) }
+  let(:column) { create(:column, project: project) }
+  let(:card) do
+    create(:card, name: 'テスト', project: project, column: column,
+                  due_date: '2019/01/01', assignee_id: user.id)
+  end
+
+  describe '#after_save' do
+    context 'due_dateが変更された場合' do
+      before { card.due_date = '2019/08/01' }
+
+      it '結果が正しいこと' do
+        expect { card.save }
+          .to change { Log.where('content LIKE(?)', '%カードの期限%').count }
+          .by(1)
+      end
+    end
+
+    context 'assignee_idが変更された場合' do
+      before do
+        new_user = create(:user)
+        new_user.participate_in(project)
+        card.assignee_id = new_user.id
+      end
+
+      it '結果が正しいこと' do
+        expect { card.save }
+          .to change { Log.where('content LIKE(?)', '%カード%アサイン%').count }
+          .by(1)
+      end
+    end
+  end
+
+  describe '#content_for_due_date' do
+    context '操作者が設定されている場合' do
+      before { card.operator = user }
+
+      context '新しい期限を設定した場合' do
+        before { card.due_date = '2019/08/01' }
+
+        it '内容が正しいこと' do
+          card.save
+          log = Log.where('content LIKE(?)', '%カードの期限%').last
+          expect(log.content).to eq '山田太郎さんがテストカードの期限を2019/08/01に設定しました'
+          expect(log.project).to eq project
+        end
+      end
+
+      context '期限をなしに設定した場合' do
+        before { card.due_date = nil }
+
+        it '内容が正しいこと' do
+          card.save
+          log = Log.where('content LIKE(?)', '%カードの期限%').last
+          expect(log.content).to eq '山田太郎さんがテストカードの期限をなしに設定しました'
+          expect(log.project).to eq project
+        end
+      end
+    end
+
+    context '操作者が設定されていない場合' do
+      context '新しい期限を設定した場合' do
+        before { card.due_date = '2019/08/01' }
+
+        it '内容が正しいこと' do
+          card.save
+          log = Log.where('content LIKE(?)', '%カードの期限%').last
+          expect(log.content).to eq 'テストカードの期限が2019/08/01に設定されました'
+          expect(log.project).to eq project
+        end
+      end
+
+      context '期限をなしに設定した場合' do
+        before { card.due_date = nil }
+
+        it '内容が正しいこと' do
+          card.save
+          log = Log.where('content LIKE(?)', '%カードの期限%').last
+          expect(log.content).to eq 'テストカードの期限がなしに設定されました'
+          expect(log.project).to eq project
+        end
+      end
+    end
+  end
+
+  describe '#content_for_assignee_id' do
+    before do
+      new_user = create(:user, name: '佐藤花子')
+      new_user.participate_in(project)
+      card.assignee_id = new_user.id
+    end
+
+    context '操作者が設定されている場合' do
+      before { card.operator = user }
+
+      it '内容が正しいこと' do
+        card.save
+        log = Log.where('content LIKE(?)', '%カード%アサイン%').last
+        expect(log.content).to eq '山田太郎さんがテストカードを佐藤花子さんにアサインしました'
+        expect(log.project).to eq project
+      end
+    end
+
+    context '操作者が設定されていない場合' do
+      it '内容が正しいこと' do
+        card.save
+        log = Log.where('content LIKE(?)', '%カード%アサイン%').last
+        expect(log.content).to eq 'テストカードが佐藤花子さんにアサインされました'
+        expect(log.project).to eq project
+      end
+    end
+  end
+end

--- a/spec/callbacks/card_update_logs_callbacks_spec.rb
+++ b/spec/callbacks/card_update_logs_callbacks_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe CardUpdateLogsCallbacks, type: :callback do
+  let(:user) { create(:user, name: '山田太郎') }
+  let(:project) { create(:project, owner: user) }
+  let(:column) { create(:column, project: project) }
+  let(:card) { create(:card, name: 'テスト', project: project, column: column) }
+
+  describe '#after_update' do
+    it '結果が正しいこと' do
+      expect { card.update(name: 'アップデート') }
+        .to change { Log.where('content LIKE(?)', '%カードの名前%編集%').count }
+        .by(1)
+    end
+  end
+
+  describe '#content' do
+    context '操作者が設定されている場合' do
+      before { card.operator = user }
+
+      it '内容が正しいこと' do
+        card.update(name: 'アップデート')
+        log = Log.where('content LIKE(?)', '%カードの名前%編集%').last
+        expect(log.content).to eq '山田太郎さんがテストカードの名前をアップデートに編集しました'
+        expect(log.project).to eq project
+      end
+    end
+
+    context '操作者が設定されていない場合' do
+      it '内容が正しいこと' do
+        card.update(name: 'アップデート')
+        log = Log.where('content LIKE(?)', '%カードの名前%編集%').last
+        expect(log.content).to eq 'テストカードの名前がアップデートに編集されました'
+        expect(log.project).to eq project
+      end
+    end
+  end
+end

--- a/spec/callbacks/column_create_logs_callbacks_spec.rb
+++ b/spec/callbacks/column_create_logs_callbacks_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe ColumnCreateLogsCallbacks, type: :callback do
+  let(:user) { create(:user, name: '山田太郎') }
+  let(:project) { create(:project, owner: user) }
+  let(:column) { build(:column, name: 'テスト', project: project) }
+
+  describe '#after_create' do
+    it '結果が正しいこと' do
+      expect { column.save }
+        .to change { Log.where('content LIKE(?)', '%カラム%作成%').count }.by(1)
+    end
+  end
+
+  describe '#content' do
+    context '操作者が設定されている場合' do
+      before { column.operator = user }
+
+      it '内容が正しいこと' do
+        column.save
+        log = Log.where('content LIKE(?)', '%カラム%作成%').last
+        expect(log.content).to eq '山田太郎さんがテストカラムを作成しました'
+        expect(log.project).to eq project
+      end
+    end
+
+    context '操作者が設定されていない場合' do
+      it '内容が正しいこと' do
+        column.save
+        log = Log.where('content LIKE(?)', '%カラム%作成%').last
+        expect(log.content).to eq 'テストカラムが作成されました'
+        expect(log.project).to eq project
+      end
+    end
+  end
+end

--- a/spec/callbacks/column_destroy_logs_callbacks_spec.rb
+++ b/spec/callbacks/column_destroy_logs_callbacks_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe ColumnDestroyLogsCallbacks, type: :callback do
+  let(:user) { create(:user, name: '山田太郎') }
+  let(:project) { create(:project, owner: user) }
+  let(:column) { create(:column, name: 'テスト', project: project) }
+
+  describe '#after_destroy' do
+    it '結果が正しいこと' do
+      expect { column.destroy }
+        .to change { Log.where('content LIKE(?)', '%カラム%削除%').count }.by(1)
+    end
+  end
+
+  describe '#content' do
+    context '操作者が設定されている場合' do
+      before { column.operator = user }
+
+      it '内容が正しいこと' do
+        column.destroy
+        log = Log.where('content LIKE(?)', '%カラム%削除%').last
+        expect(log.content).to eq '山田太郎さんがテストカラムを削除しました'
+        expect(log.project).to eq project
+      end
+    end
+
+    context '操作者が設定されていない場合' do
+      it '内容が正しいこと' do
+        column.destroy
+        log = Log.where('content LIKE(?)', '%カラム%削除%').last
+        expect(log.content).to eq 'テストカラムが削除されました'
+        expect(log.project).to eq project
+      end
+    end
+  end
+end

--- a/spec/callbacks/column_update_logs_callbacks_spec.rb
+++ b/spec/callbacks/column_update_logs_callbacks_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe ColumnUpdateLogsCallbacks, type: :callback do
+  let(:user) { create(:user, name: '山田太郎') }
+  let(:project) { create(:project, owner: user) }
+  let(:column) { create(:column, name: 'テスト', project: project) }
+
+  describe '#after_update' do
+    it '結果が正しいこと' do
+      expect { column.update(name: 'アップデート') }
+        .to change { Log.where('content LIKE(?)', '%カラムの名前%編集%').count }
+        .by(1)
+    end
+  end
+
+  describe '#content' do
+    context '操作者が設定されている場合' do
+      before { column.operator = user }
+
+      it '内容が正しいこと' do
+        column.update(name: 'アップデート')
+        log = Log.where('content LIKE(?)', '%カラムの名前%編集%').last
+        expect(log.content).to eq '山田太郎さんがテストカラムの名前をアップデートに編集しました'
+        expect(log.project).to eq project
+      end
+    end
+
+    context '操作者が設定されていない場合' do
+      it '内容が正しいこと' do
+        column.update(name: 'アップデート')
+        log = Log.where('content LIKE(?)', '%カラムの名前%編集%').last
+        expect(log.content).to eq 'テストカラムの名前がアップデートに編集されました'
+        expect(log.project).to eq project
+      end
+    end
+  end
+end

--- a/spec/callbacks/invitation_create_logs_callbacks_spec.rb
+++ b/spec/callbacks/invitation_create_logs_callbacks_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe InvitationCreateLogsCallbacks, type: :callback do
+  let(:owner) { create(:user, name: '山田太郎') }
+  let(:user) { create(:user, name: '佐藤花子') }
+  let(:project) { create(:project, owner: owner) }
+
+  describe '#after_create' do
+    it '結果が正しいこと' do
+      expect { project.invite(user) }
+        .to change { Log.where('content LIKE(?)', '%招待%').count }.by(1)
+    end
+  end
+
+  describe '#content' do
+    it '内容が正しいこと' do
+      project.invite(user)
+      log = Log.where('content LIKE(?)', '%招待%').last
+      expect(log.content).to eq '山田太郎さんが佐藤花子さんをこのプロジェクトに招待しました'
+      expect(log.project).to eq project
+    end
+  end
+end

--- a/spec/callbacks/participation_create_logs_callbacks_spec.rb
+++ b/spec/callbacks/participation_create_logs_callbacks_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ParticipationCreateLogsCallbacks, type: :callback do
+  let(:project) { create(:project) }
+  let(:user) { create(:user, name: '佐藤花子') }
+
+  describe '#after_create' do
+    it '結果が正しいこと' do
+      expect { user.participate_in(project) }
+        .to change { Log.where('content LIKE(?)', '%参加%').count }.by(1)
+    end
+  end
+
+  describe '#content' do
+    it '内容が正しいこと' do
+      user.participate_in(project)
+      log = Log.where('content LIKE(?)', '%参加%').last
+      expect(log.content).to eq '佐藤花子さんがこのプロジェクトに参加しました'
+      expect(log.project).to eq project
+    end
+  end
+end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe Log, type: :model do
+  describe '.create_due_date_notification_logs!' do
+    let!(:project) { create(:project) }
+    let!(:column) { create(:column, project: project) }
+
+    context 'ログ出力条件に該当するデータがある場合' do
+      context '本日が期限のカードがある場合' do
+        let!(:card) do
+          create(:card, project: project, column: column,
+                        due_date: Date.today, name: 'テスト')
+        end
+
+        it '結果が正しいこと' do
+          expect { Log.create_due_date_notification_logs! }
+            .to change { Log.count }.by(1)
+        end
+
+        it '内容が正しいこと' do
+          Log.create_due_date_notification_logs!
+          expect(Log.last.content).to eq '本日がテストカードの締切期限です'
+          expect(Log.last.project).to eq project
+        end
+      end
+
+      context '期限を過ぎたカードがある場合' do
+        let!(:card) do
+          create(:card, project: project, column: column,
+                        due_date: Date.today - 3.days, name: 'テスト')
+        end
+
+        it '結果が正しいこと' do
+          expect { Log.create_due_date_notification_logs! }
+            .to change { Log.count }.by(1)
+        end
+
+        it '内容が正しいこと' do
+          Log.create_due_date_notification_logs!
+          expect(Log.last.content).to eq 'テストカードの締切期限が3日過ぎました'
+          expect(Log.last.project).to eq project
+        end
+      end
+    end
+
+    context 'ログ出力条件に該当するデータがない場合' do
+      let!(:card) do
+        create(:card, project: project, column: column,
+                      due_date: Date.today + 3.days, name: 'テスト')
+      end
+
+      it '結果が正しいこと' do
+        expect { Log.create_due_date_notification_logs! }
+          .not_to(change { Log.count })
+      end
+    end
+
+    context 'ログ出力条件に該当するデータが複数ある場合' do
+      before do
+        create(:card, project: project, column: column,
+                      due_date: Date.today, name: '該当する1')
+        create(:card, project: project, column: column,
+                      due_date: Date.today - 3.days, name: '該当する2')
+        create(:card, project: project, column: column,
+                      due_date: Date.today + 3.days, name: '該当しない')
+      end
+
+      it '結果が正しいこと' do
+        expect { Log.create_due_date_notification_logs! }
+          .to change { Log.count }.by(2)
+      end
+    end
+  end
+end

--- a/spec/rake_helper.rb
+++ b/spec/rake_helper.rb
@@ -1,0 +1,12 @@
+require 'rake'
+RSpec.configure do |config|
+  config.before(:suite) do
+    # Load all the tasks just as Rails does (`load 'Rakefile'` is another simple way)
+    Rails.application.load_tasks
+  end
+
+  config.before(:each) do
+    # Remove persistency between examples
+    Rake.application.tasks.each(&:reenable)
+  end
+end

--- a/spec/tasks/log_due_date_spec.rb
+++ b/spec/tasks/log_due_date_spec.rb
@@ -1,0 +1,11 @@
+require 'rake_helper'
+
+describe 'log:due_date' do
+  let(:task) { Rake.application['log:due_date'] }
+  before { allow(Log).to receive(:create_due_date_notification_logs!) }
+
+  it 'Log.create_due_date_notification_logs!が呼び出されること' do
+    task.invoke
+    expect(Log).to have_received(:create_due_date_notification_logs!)
+  end
+end


### PR DESCRIPTION
ref #25 
ログ機能を作成しました。
- ログ表示画面を作成
- ログモデルを作成
- カード、カラム、招待、参加モデルのコールバックでログを作成するよう設定。`callbacks/`以下のクラスに委譲して処理を作成。
- ログモデルに、カードの期限を参照してログを生成するcreate_due_date_notification_logs!クラスメソッドを作成。
- 上記のメソッドを実行するrakeタスク`log_due_date.rake`を作成。
（herokuスケジューラに上記rakeタスクを登録して定期処理を実行する。）