### PR TITLE
ログ用コールバッククラスのテストを修正

### DIFF
--- a/spec/callbacks/card_create_logs_callbacks_spec.rb
+++ b/spec/callbacks/card_create_logs_callbacks_spec.rb
@@ -1,34 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe CardCreateLogsCallbacks, type: :callback do
-  let(:user) { create(:user, name: '山田太郎') }
-  let(:project) { create(:project, owner: user) }
-  let(:column) { create(:column, project: project) }
+  let!(:user) { create(:user, name: '山田太郎') }
+  let!(:project) { create(:project, owner: user) }
+  let!(:column) { create(:column, project: project) }
   let(:card) { build(:card, name: 'テスト', project: project, column: column) }
 
   describe '#after_create' do
-    it '結果が正しいこと' do
-      expect { card.save }
-        .to change { Log.where('content LIKE(?)', '%カード%作成%').count }.by(1)
-    end
-  end
-
-  describe '#content' do
     context '操作者が設定されている場合' do
       before { card.operator = user }
 
-      it '内容が正しいこと' do
-        card.save
-        log = Log.where('content LIKE(?)', '%カード%作成%').last
+      it 'ログが1件作成されること' do
+        expect { card.run_callbacks(:create) }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
+        card.run_callbacks(:create)
+        log = Log.order(:created_at).last
         expect(log.content).to eq '山田太郎さんがテストカードを作成しました'
         expect(log.project).to eq project
       end
     end
 
-    context '操作者が設定されていない場合' do
-      it '内容が正しいこと' do
-        card.save
-        log = Log.where('content LIKE(?)', '%カード%作成%').last
+    context '操作者が特定されていない場合' do
+      it 'ログが1件作成されること' do
+        expect { card.run_callbacks(:create) }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
+        card.run_callbacks(:create)
+        log = Log.order(:created_at).last
         expect(log.content).to eq 'テストカードが作成されました'
         expect(log.project).to eq project
       end

--- a/spec/callbacks/card_destroy_logs_callbacks_spec.rb
+++ b/spec/callbacks/card_destroy_logs_callbacks_spec.rb
@@ -1,34 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe CardDestroyLogsCallbacks, type: :callback do
-  let(:user) { create(:user, name: '山田太郎') }
-  let(:project) { create(:project, owner: user) }
-  let(:column) { create(:column, name: 'サンプル', project: project) }
-  let(:card) { create(:card, name: 'テスト', project: project, column: column) }
+  let!(:user) { create(:user, name: '山田太郎') }
+  let!(:project) { create(:project, owner: user) }
+  let!(:column) { create(:column, name: 'サンプル', project: project) }
+  let!(:card) { create(:card, name: 'テスト', project: project, column: column) }
 
   describe '#after_destroy' do
-    it '結果が正しいこと' do
-      expect { card.destroy }
-        .to change { Log.where('content LIKE(?)', '%カード%削除%').count }.by(1)
-    end
-  end
-
-  describe '#content' do
     context '操作者が設定されている場合' do
       before { card.operator = user }
 
-      it '内容が正しいこと' do
+      it 'ログが1件作成されること' do
+        expect { card.destroy }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
         card.destroy
-        log = Log.where('content LIKE(?)', '%カード%削除%').last
+        log = Log.order(:created_at).last
         expect(log.content).to eq '山田太郎さんがテストカードを削除しました'
         expect(log.project).to eq project
       end
     end
 
     context '操作者が設定されていない場合' do
-      it '内容が正しいこと' do
+      it 'ログが1件作成されること' do
+        expect { card.destroy }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
         card.destroy
-        log = Log.where('content LIKE(?)', '%カード%削除%').last
+        log = Log.order(:created_at).last
         expect(log.content).to eq 'サンプルカラムのテストカードが削除されました'
         expect(log.project).to eq project
       end

--- a/spec/callbacks/card_save_logs_callbacks_spec.rb
+++ b/spec/callbacks/card_save_logs_callbacks_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe CardSaveLogsCallbacks, type: :callback do
-  let(:user) { create(:user, name: '山田太郎') }
-  let(:project) { create(:project, owner: user) }
-  let(:column) { create(:column, project: project) }
-  let(:card) do
+  let!(:user) { create(:user, name: '山田太郎') }
+  let!(:project) { create(:project, owner: user) }
+  let!(:column) { create(:column, project: project) }
+  let!(:card) do
     create(:card, name: 'テスト', project: project, column: column,
                   due_date: '2019/01/01', assignee_id: user.id)
   end
@@ -13,104 +13,133 @@ RSpec.describe CardSaveLogsCallbacks, type: :callback do
     context 'due_dateが変更された場合' do
       before { card.due_date = '2019/08/01' }
 
-      it '結果が正しいこと' do
-        expect { card.save }
-          .to change { Log.where('content LIKE(?)', '%カードの期限%').count }
-          .by(1)
+      context '操作者が設定されている場合' do
+        before { card.operator = user }
+
+        context '新しい期限を設定した場合' do
+          before { card.due_date = '2019/08/01' }
+
+          it 'ログが1件作成されること' do
+            expect { card.save }.to change { Log.count }.by(1)
+          end
+
+          it 'ログの内容が正しいこと' do
+            card.save
+            log = Log.order(:created_at).last
+            expect(log.content)
+              .to eq '山田太郎さんがテストカードの期限を2019/08/01に設定しました'
+            expect(log.project).to eq project
+          end
+        end
+
+        context '期限をなしに設定した場合' do
+          before { card.due_date = nil }
+
+          it 'ログが1件作成されること' do
+            expect { card.save }.to change { Log.count }.by(1)
+          end
+
+          it 'ログの内容が正しいこと' do
+            card.save
+            log = Log.order(:created_at).last
+            expect(log.content)
+              .to eq '山田太郎さんがテストカードの期限をなしに設定しました'
+            expect(log.project).to eq project
+          end
+        end
+      end
+
+      context '操作者が設定されていない場合' do
+        context '新しい期限を設定した場合' do
+          before { card.due_date = '2019/08/01' }
+
+          it 'ログが1件作成されること' do
+            expect { card.save }.to change { Log.count }.by(1)
+          end
+
+          it 'ログの内容が正しいこと' do
+            card.save
+            log = Log.order(:created_at).last
+            expect(log.content).to eq 'テストカードの期限が2019/08/01に設定されました'
+            expect(log.project).to eq project
+          end
+        end
+
+        context '期限をなしに設定した場合' do
+          before { card.due_date = nil }
+
+          it 'ログが1件作成されること' do
+            expect { card.save }.to change { Log.count }.by(1)
+          end
+
+          it 'ログの内容が正しいこと' do
+            card.save
+            log = Log.order(:created_at).last
+            expect(log.content).to eq 'テストカードの期限がなしに設定されました'
+            expect(log.project).to eq project
+          end
+        end
       end
     end
 
     context 'assignee_idが変更された場合' do
       before do
-        new_user = create(:user)
+        new_user = create(:user, name: '佐藤花子')
         new_user.participate_in(project)
         card.assignee_id = new_user.id
       end
 
-      it '結果が正しいこと' do
-        expect { card.save }
-          .to change { Log.where('content LIKE(?)', '%カード%アサイン%').count }
-          .by(1)
-      end
-    end
-  end
+      context '操作者が設定されている場合' do
+        before { card.operator = user }
 
-  describe '#content_for_due_date' do
-    context '操作者が設定されている場合' do
-      before { card.operator = user }
+        it 'ログが1件作成されること' do
+          expect { card.save }.to change { Log.count }.by(1)
+        end
 
-      context '新しい期限を設定した場合' do
-        before { card.due_date = '2019/08/01' }
-
-        it '内容が正しいこと' do
+        it 'ログの内容が正しいこと' do
           card.save
-          log = Log.where('content LIKE(?)', '%カードの期限%').last
-          expect(log.content).to eq '山田太郎さんがテストカードの期限を2019/08/01に設定しました'
+          log = Log.order(:created_at).last
+          expect(log.content)
+            .to eq '山田太郎さんがテストカードを佐藤花子さんにアサインしました'
           expect(log.project).to eq project
         end
       end
 
-      context '期限をなしに設定した場合' do
-        before { card.due_date = nil }
+      context '操作者が設定されていない場合' do
+        it 'ログが1件作成されること' do
+          expect { card.save }.to change { Log.count }.by(1)
+        end
 
-        it '内容が正しいこと' do
+        it 'ログの内容が正しいこと' do
           card.save
-          log = Log.where('content LIKE(?)', '%カードの期限%').last
-          expect(log.content).to eq '山田太郎さんがテストカードの期限をなしに設定しました'
+          log = Log.order(:created_at).last
+          expect(log.content).to eq 'テストカードが佐藤花子さんにアサインされました'
           expect(log.project).to eq project
         end
       end
     end
 
-    context '操作者が設定されていない場合' do
-      context '新しい期限を設定した場合' do
-        before { card.due_date = '2019/08/01' }
-
-        it '内容が正しいこと' do
-          card.save
-          log = Log.where('content LIKE(?)', '%カードの期限%').last
-          expect(log.content).to eq 'テストカードの期限が2019/08/01に設定されました'
-          expect(log.project).to eq project
-        end
+    context 'due_dateとassignee_idが変更された場合' do
+      before do
+        card.due_date = '2019/08/01'
+        new_user = create(:user, name: '佐藤花子')
+        new_user.participate_in(project)
+        card.assignee_id = new_user.id
       end
 
-      context '期限をなしに設定した場合' do
-        before { card.due_date = nil }
-
-        it '内容が正しいこと' do
-          card.save
-          log = Log.where('content LIKE(?)', '%カードの期限%').last
-          expect(log.content).to eq 'テストカードの期限がなしに設定されました'
-          expect(log.project).to eq project
-        end
+      it 'ログが2件作成されること' do
+        expect { card.save }.to change { Log.count }.by(2)
       end
-    end
-  end
 
-  describe '#content_for_assignee_id' do
-    before do
-      new_user = create(:user, name: '佐藤花子')
-      new_user.participate_in(project)
-      card.assignee_id = new_user.id
-    end
-
-    context '操作者が設定されている場合' do
-      before { card.operator = user }
-
-      it '内容が正しいこと' do
+      it 'ログの内容が正しいこと' do
         card.save
-        log = Log.where('content LIKE(?)', '%カード%アサイン%').last
-        expect(log.content).to eq '山田太郎さんがテストカードを佐藤花子さんにアサインしました'
-        expect(log.project).to eq project
-      end
-    end
+        due_date_log = project.logs.order(:created_at).second_to_last
+        assignee_id_log = project.logs.order(:created_at).last
 
-    context '操作者が設定されていない場合' do
-      it '内容が正しいこと' do
-        card.save
-        log = Log.where('content LIKE(?)', '%カード%アサイン%').last
-        expect(log.content).to eq 'テストカードが佐藤花子さんにアサインされました'
-        expect(log.project).to eq project
+        expect(due_date_log.content)
+          .to eq 'テストカードの期限が2019/08/01に設定されました'
+        expect(assignee_id_log.content)
+          .to eq 'テストカードが佐藤花子さんにアサインされました'
       end
     end
   end

--- a/spec/callbacks/card_update_logs_callbacks_spec.rb
+++ b/spec/callbacks/card_update_logs_callbacks_spec.rb
@@ -1,35 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe CardUpdateLogsCallbacks, type: :callback do
-  let(:user) { create(:user, name: '山田太郎') }
-  let(:project) { create(:project, owner: user) }
-  let(:column) { create(:column, project: project) }
-  let(:card) { create(:card, name: 'テスト', project: project, column: column) }
+  let!(:user) { create(:user, name: '山田太郎') }
+  let!(:project) { create(:project, owner: user) }
+  let!(:column) { create(:column, project: project) }
+  let!(:card) { create(:card, name: 'テスト', project: project, column: column) }
 
   describe '#after_update' do
-    it '結果が正しいこと' do
-      expect { card.update(name: 'アップデート') }
-        .to change { Log.where('content LIKE(?)', '%カードの名前%編集%').count }
-        .by(1)
-    end
-  end
-
-  describe '#content' do
     context '操作者が設定されている場合' do
       before { card.operator = user }
 
-      it '内容が正しいこと' do
+      it 'ログが1件作成されること' do
+        expect { card.update(name: 'アップデート') }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
         card.update(name: 'アップデート')
-        log = Log.where('content LIKE(?)', '%カードの名前%編集%').last
-        expect(log.content).to eq '山田太郎さんがテストカードの名前をアップデートに編集しました'
+        log = Log.order(:created_at).last
+        expect(log.content)
+          .to eq '山田太郎さんがテストカードの名前をアップデートに編集しました'
         expect(log.project).to eq project
       end
     end
 
     context '操作者が設定されていない場合' do
-      it '内容が正しいこと' do
+      it 'ログが1件作成されること' do
+        expect { card.update(name: 'アップデート') }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
         card.update(name: 'アップデート')
-        log = Log.where('content LIKE(?)', '%カードの名前%編集%').last
+        log = Log.order(:created_at).last
         expect(log.content).to eq 'テストカードの名前がアップデートに編集されました'
         expect(log.project).to eq project
       end

--- a/spec/callbacks/column_create_logs_callbacks_spec.rb
+++ b/spec/callbacks/column_create_logs_callbacks_spec.rb
@@ -1,33 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe ColumnCreateLogsCallbacks, type: :callback do
-  let(:user) { create(:user, name: '山田太郎') }
-  let(:project) { create(:project, owner: user) }
+  let!(:user) { create(:user, name: '山田太郎') }
+  let!(:project) { create(:project, owner: user) }
   let(:column) { build(:column, name: 'テスト', project: project) }
 
   describe '#after_create' do
-    it '結果が正しいこと' do
-      expect { column.save }
-        .to change { Log.where('content LIKE(?)', '%カラム%作成%').count }.by(1)
-    end
-  end
-
-  describe '#content' do
     context '操作者が設定されている場合' do
       before { column.operator = user }
 
-      it '内容が正しいこと' do
-        column.save
-        log = Log.where('content LIKE(?)', '%カラム%作成%').last
+      it 'ログが1件作成されること' do
+        expect { column.run_callbacks(:create) }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
+        column.run_callbacks(:create)
+        log = Log.order(:created_at).last
         expect(log.content).to eq '山田太郎さんがテストカラムを作成しました'
         expect(log.project).to eq project
       end
     end
 
     context '操作者が設定されていない場合' do
-      it '内容が正しいこと' do
-        column.save
-        log = Log.where('content LIKE(?)', '%カラム%作成%').last
+      it 'ログが1件作成されること' do
+        expect { column.run_callbacks(:create) }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
+        column.run_callbacks(:create)
+        log = Log.order(:created_at).last
         expect(log.content).to eq 'テストカラムが作成されました'
         expect(log.project).to eq project
       end

--- a/spec/callbacks/column_destroy_logs_callbacks_spec.rb
+++ b/spec/callbacks/column_destroy_logs_callbacks_spec.rb
@@ -1,33 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe ColumnDestroyLogsCallbacks, type: :callback do
-  let(:user) { create(:user, name: '山田太郎') }
-  let(:project) { create(:project, owner: user) }
-  let(:column) { create(:column, name: 'テスト', project: project) }
+  let!(:user) { create(:user, name: '山田太郎') }
+  let!(:project) { create(:project, owner: user) }
+  let!(:column) { create(:column, name: 'テスト', project: project) }
 
   describe '#after_destroy' do
-    it '結果が正しいこと' do
-      expect { column.destroy }
-        .to change { Log.where('content LIKE(?)', '%カラム%削除%').count }.by(1)
-    end
-  end
-
-  describe '#content' do
     context '操作者が設定されている場合' do
       before { column.operator = user }
 
-      it '内容が正しいこと' do
+      it 'ログが1件作成されること' do
+        expect { column.destroy }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
         column.destroy
-        log = Log.where('content LIKE(?)', '%カラム%削除%').last
+        log = Log.order(:created_at).last
         expect(log.content).to eq '山田太郎さんがテストカラムを削除しました'
         expect(log.project).to eq project
       end
     end
 
     context '操作者が設定されていない場合' do
-      it '内容が正しいこと' do
+      it 'ログが1件作成されること' do
+        expect { column.destroy }.to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
         column.destroy
-        log = Log.where('content LIKE(?)', '%カラム%削除%').last
+        log = Log.order(:created_at).last
         expect(log.content).to eq 'テストカラムが削除されました'
         expect(log.project).to eq project
       end

--- a/spec/callbacks/column_update_logs_callbacks_spec.rb
+++ b/spec/callbacks/column_update_logs_callbacks_spec.rb
@@ -1,34 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe ColumnUpdateLogsCallbacks, type: :callback do
-  let(:user) { create(:user, name: '山田太郎') }
-  let(:project) { create(:project, owner: user) }
-  let(:column) { create(:column, name: 'テスト', project: project) }
+  let!(:user) { create(:user, name: '山田太郎') }
+  let!(:project) { create(:project, owner: user) }
+  let!(:column) { create(:column, name: 'テスト', project: project) }
 
   describe '#after_update' do
-    it '結果が正しいこと' do
-      expect { column.update(name: 'アップデート') }
-        .to change { Log.where('content LIKE(?)', '%カラムの名前%編集%').count }
-        .by(1)
-    end
-  end
-
-  describe '#content' do
     context '操作者が設定されている場合' do
       before { column.operator = user }
 
-      it '内容が正しいこと' do
+      it 'ログが1件作成されること' do
+        expect { column.update(name: 'アップデート') }
+          .to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
         column.update(name: 'アップデート')
-        log = Log.where('content LIKE(?)', '%カラムの名前%編集%').last
-        expect(log.content).to eq '山田太郎さんがテストカラムの名前をアップデートに編集しました'
+        log = Log.order(:created_at).last
+        expect(log.content)
+          .to eq '山田太郎さんがテストカラムの名前をアップデートに編集しました'
         expect(log.project).to eq project
       end
     end
 
     context '操作者が設定されていない場合' do
-      it '内容が正しいこと' do
+      it 'ログが1件作成されること' do
+        expect { column.update(name: 'アップデート') }
+          .to change { Log.count }.by(1)
+      end
+
+      it 'ログの内容が正しいこと' do
         column.update(name: 'アップデート')
-        log = Log.where('content LIKE(?)', '%カラムの名前%編集%').last
+        log = Log.order(:created_at).last
         expect(log.content).to eq 'テストカラムの名前がアップデートに編集されました'
         expect(log.project).to eq project
       end

--- a/spec/callbacks/invitation_create_logs_callbacks_spec.rb
+++ b/spec/callbacks/invitation_create_logs_callbacks_spec.rb
@@ -1,22 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe InvitationCreateLogsCallbacks, type: :callback do
-  let(:owner) { create(:user, name: '山田太郎') }
-  let(:user) { create(:user, name: '佐藤花子') }
-  let(:project) { create(:project, owner: owner) }
+  let!(:owner) { create(:user, name: '山田太郎') }
+  let!(:user) { create(:user, name: '佐藤花子') }
+  let!(:project) { create(:project, owner: owner) }
 
   describe '#after_create' do
-    it '結果が正しいこと' do
-      expect { project.invite(user) }
-        .to change { Log.where('content LIKE(?)', '%招待%').count }.by(1)
+    it 'ログが1件作成されること' do
+      expect { project.invite(user) }.to change { Log.count }.by(1)
     end
-  end
 
-  describe '#content' do
-    it '内容が正しいこと' do
+    it 'ログの内容が正しいこと' do
       project.invite(user)
-      log = Log.where('content LIKE(?)', '%招待%').last
-      expect(log.content).to eq '山田太郎さんが佐藤花子さんをこのプロジェクトに招待しました'
+      log = Log.order(:created_at).last
+      expect(log.content)
+        .to eq '山田太郎さんが佐藤花子さんをこのプロジェクトに招待しました'
       expect(log.project).to eq project
     end
   end

--- a/spec/callbacks/participation_create_logs_callbacks_spec.rb
+++ b/spec/callbacks/participation_create_logs_callbacks_spec.rb
@@ -1,20 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe ParticipationCreateLogsCallbacks, type: :callback do
-  let(:project) { create(:project) }
-  let(:user) { create(:user, name: '佐藤花子') }
+  let!(:project) { create(:project) }
+  let!(:user) { create(:user, name: '佐藤花子') }
 
   describe '#after_create' do
-    it '結果が正しいこと' do
-      expect { user.participate_in(project) }
-        .to change { Log.where('content LIKE(?)', '%参加%').count }.by(1)
+    it 'ログが1件作成されること' do
+      expect { user.participate_in(project) }.to change { Log.count }.by(1)
     end
-  end
 
-  describe '#content' do
-    it '内容が正しいこと' do
+    it 'ログの内容が正しいこと' do
       user.participate_in(project)
-      log = Log.where('content LIKE(?)', '%参加%').last
+      log = Log.order(:created_at).last
       expect(log.content).to eq '佐藤花子さんがこのプロジェクトに参加しました'
       expect(log.project).to eq project
     end


### PR DESCRIPTION
ログ用コールバッククラスのテストを修正しました。

- コールバックでログが作成されることの検証で、作成されるログの件数の検証方法が曖昧だったため、正確に件数を検証できるよう修正した。